### PR TITLE
Improve multi-ruby development experience

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -110,24 +110,27 @@ namespace :docker do
   desc "Build docker image for given ruby version"
   task :build, [:version] do |t, args|
     version = args[:version] || ENV["VERSION"]
-    raise ArgumentError, "You must specify a supported Ruby version." unless SUPPORTED_RUBY_VERSIONS.include?(version)
+    versioned_task_name = "docker:build_ruby_#{args[:version]}"
+    raise ArgumentError, "You must specify a supported Ruby version. Available versions: #{SUPPORTED_RUBY_VERSIONS.join(", ")}" unless Rake::Task.task_defined?(versioned_task_name)
 
-    Rake::Task["docker:build_ruby_#{args[:version]}"].invoke
+    Rake::Task[versioned_task_name].invoke
   end
 
   desc "Open a shell in the docker image for given ruby version"
   task :shell, [:version] do |t, args|
     version = args[:version] || ENV["VERSION"]
-    raise ArgumentError, "You must specify a supported Ruby version." unless SUPPORTED_RUBY_VERSIONS.include?(version)
+    versioned_task_name = "docker:shell_ruby_#{args[:version]}"
+    raise ArgumentError, "You must specify a supported Ruby version. Available versions: #{SUPPORTED_RUBY_VERSIONS.join(", ")}" unless Rake::Task.task_defined?(versioned_task_name)
 
-    Rake::Task["docker:shell_ruby_#{args[:version]}"].invoke
+    Rake::Task[versioned_task_name].invoke
   end
 
   desc "Run tests in the docker image for given ruby version"
   task :test, [:version] do |t, args|
     version = args[:version] || ENV["VERSION"]
-    raise ArgumentError, "You must specify a supported Ruby version." unless SUPPORTED_RUBY_VERSIONS.include?(version)
+    versioned_task_name = "docker:test_ruby_#{args[:version]}"
+    raise ArgumentError, "You must specify a supported Ruby version. Available versions: #{SUPPORTED_RUBY_VERSIONS.join(", ")}" unless Rake::Task.task_defined?(versioned_task_name)
 
-    Rake::Task["docker:test_ruby_#{args[:version]}"].invoke
+    Rake::Task[versioned_task_name].invoke
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -83,16 +83,26 @@ namespace :docker do
   # Depending on tasks with variables is basically impossible, so we define "internal" tasks
   # with the ruby version in the name of the task.
   SUPPORTED_RUBY_VERSIONS.each do |version|
+    service = "ruby-#{version.gsub(".", "-")}"
+
     task "build_ruby_#{version}" => "docker-compose.yml" do
-      sh "docker", "compose", "build", "ruby-#{version.gsub(".", "-")}"
+      sh "docker", "compose", "build", service
     end
 
     task "shell_ruby_#{version}" => "build_ruby_#{version}" do
-      sh "docker", "compose", "run", "ruby-#{version.gsub(".", "-")}", "bash"
+      sh "docker", "compose", "run", service, "bash"
     end
 
     task "test_ruby_#{version}" => "build_ruby_#{version}" do
-      sh "docker", "compose", "run", "ruby-#{version.gsub(".", "-")}", "bundle", "exec", "rake", "test"
+      sh "docker", "compose", "run", service, "bundle", "exec", "rake", "test"
+    end
+
+    # Shorthand for Ruby 2.1+ (eg, `rake docker:build_ruby_2.1` -> `rake docker:build_ruby_2.1.10`)
+    if version != "1.9.3" && version != "2.0.0"
+      short_version = version.split(".").first(2).join(".")
+      task "build_ruby_#{short_version}" => "build_ruby_#{version}"
+      task "shell_ruby_#{short_version}" => "shell_ruby_#{version}"
+      task "test_ruby_#{short_version}" => "test_ruby_#{version}"
     end
   end
 


### PR DESCRIPTION
## What?

- [x] Support `rake docker:build[2.2]` as well as `rake docker:build[2.2.10]`

## Why?

I got irritated having to look up the specific version of Ruby 2.1+ to call when I just wanted to specify major.minor on the cli. Fix it by defining some extra rake tasks with prerequisites.
