### PR TITLE
More message de dup

### DIFF
--- a/lib/agent/ruby_receiver.rb
+++ b/lib/agent/ruby_receiver.rb
@@ -16,7 +16,7 @@ module OasAgent
         message = {
           type: "ruby",
           version: RUBY_VERSION,
-          message: cleanup_ruby_kwargs_warning_message(message).strip,
+          message: cleanup_keyword_argument_as_last_hash_parameter_message(cleanup_ruby_kwargs_warning_message(message)).strip,
           callstack: callstack.map(&:to_s)
         }
 
@@ -35,6 +35,15 @@ module OasAgent
         kwargs_message = "Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call"
         if message.end_with? kwargs_message
           return kwargs_message
+        else
+          return message
+        end
+      end
+
+      def cleanup_keyword_argument_as_last_hash_parameter_message(message)
+        message_suffix = "Passing the keyword argument as the last hash parameter is deprecated"
+        if message.end_with? message_suffix
+          return message_suffix
         else
           return message
         end

--- a/test/lib/agent/ruby_receiver_test.rb
+++ b/test/lib/agent/ruby_receiver_test.rb
@@ -4,31 +4,31 @@ require "test_helper"
 require "agent/agent"
 
 class OasAgentRubyReceiverTest < Minitest::Test
-  def test_strips_location_from_kwargs_message
+  def test_leaves_messages_it_doesnt_recognise_unchanged
     fake_reporter = []
     r = OasAgent::Agent::RubyReceiver.new(reporter: fake_reporter, root: "/a/b/c")
-    r.push("/home/runner/app/lib/resource_list.rb:100: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call", ["a", "b"])
-    assert_equal "Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call", fake_reporter.first[:message]
+    r.push("/home/runner/app/lib/resource_list.rb:100: info: Passing the keyword argument as the last hash parameter is OK thanks", ["a", "b"])
+    assert_equal "/home/runner/app/lib/resource_list.rb:100: info: Passing the keyword argument as the last hash parameter is OK thanks", fake_reporter.first[:message]
   end
 
-  def test_leaves_non_kwargs_messages_unchanged
-    fake_reporter = []
-    r = OasAgent::Agent::RubyReceiver.new(reporter: fake_reporter, root: "/a/b/c")
-    r.push("/home/runner/app/lib/resource_list.rb:100: warning: Using the last argument as keyword parameters is OK, carry on", ["a", "b"])
-    assert_equal "/home/runner/app/lib/resource_list.rb:100: warning: Using the last argument as keyword parameters is OK, carry on", fake_reporter.first[:message]
-  end
+  def test_automatically_strips_location_and_preamble_from_ruby_warnings
+    expected_message = "Passing the keyword argument as the last hash parameter is deprecated #{rand(1000)}"
+    deprecation_message = "/home/runner/work/someapp/app/models/conference_assignment/assignment.rb:20: warning: #{expected_message}"
+    callstack = [
+      "/home/runner/work/someapp/app/models/conference_assignment/assignment.rb:20:in `block in perform'",
+      "/home/runner/work/someapp/vendor/bundle/ruby/2.7.0/gems/dogstatsd-ruby-4.8.3/lib/datadog/statsd.rb:242:in `time'",
+      "/home/runner/work/someapp/app/models/conference_assignment/assignment.rb:15:in `perform'",
+      "/home/runner/work/someapp/app/models/conference_assignment.rb:62:in `block in perform'",
+      "/home/runner/work/someapp/app/models/concerns/database_locking.rb:68:in `block in try_with_advisory_lock'",
+      "/home/runner/work/someapp/app/models/concerns/database_locking.rb:63:in `each'",
+      "/home/runner/work/someapp/app/models/concerns/database_locking.rb:63:in `try_with_advisory_lock'",
+      "/home/runner/work/someapp/app/models/conference_assignment.rb:51:in `perform'",
+      "/home/runner/work/someapp/app/models/mymodel.rb:85:in `block in answer'"
+    ]
 
-  def test_strips_location_from_keyword_argument_as_last_hash_parameter_message
     fake_reporter = []
-    r = OasAgent::Agent::RubyReceiver.new(reporter: fake_reporter, root: "/a/b/c")
-    r.push("/home/runner/app/lib/resource_list.rb:100: warning: Passing the keyword argument as the last hash parameter is deprecated", ["a", "b"])
-    assert_equal "Passing the keyword argument as the last hash parameter is deprecated", fake_reporter.first[:message]
-  end
-
-  def test_leaves_non_keyword_argument_as_last_hash_parameter_messages_unchanged
-    fake_reporter = []
-    r = OasAgent::Agent::RubyReceiver.new(reporter: fake_reporter, root: "/a/b/c")
-    r.push("/home/runner/app/lib/resource_list.rb:100: warning: Passing the keyword argument as the last hash parameter is OK thanks", ["a", "b"])
-    assert_equal "/home/runner/app/lib/resource_list.rb:100: warning: Passing the keyword argument as the last hash parameter is OK thanks", fake_reporter.first[:message]
+    r = OasAgent::Agent::RubyReceiver.new(reporter: fake_reporter, root: "/home/runner/work/someapp")
+    r.push(deprecation_message, callstack)
+    assert_equal expected_message, fake_reporter.first[:message]
   end
 end

--- a/test/lib/agent/ruby_receiver_test.rb
+++ b/test/lib/agent/ruby_receiver_test.rb
@@ -17,4 +17,18 @@ class OasAgentRubyReceiverTest < Minitest::Test
     r.push("/home/runner/app/lib/resource_list.rb:100: warning: Using the last argument as keyword parameters is OK, carry on", ["a", "b"])
     assert_equal "/home/runner/app/lib/resource_list.rb:100: warning: Using the last argument as keyword parameters is OK, carry on", fake_reporter.first[:message]
   end
+
+  def test_strips_location_from_keyword_argument_as_last_hash_parameter_message
+    fake_reporter = []
+    r = OasAgent::Agent::RubyReceiver.new(reporter: fake_reporter, root: "/a/b/c")
+    r.push("/home/runner/app/lib/resource_list.rb:100: warning: Passing the keyword argument as the last hash parameter is deprecated", ["a", "b"])
+    assert_equal "Passing the keyword argument as the last hash parameter is deprecated", fake_reporter.first[:message]
+  end
+
+  def test_leaves_non_keyword_argument_as_last_hash_parameter_messages_unchanged
+    fake_reporter = []
+    r = OasAgent::Agent::RubyReceiver.new(reporter: fake_reporter, root: "/a/b/c")
+    r.push("/home/runner/app/lib/resource_list.rb:100: warning: Passing the keyword argument as the last hash parameter is OK thanks", ["a", "b"])
+    assert_equal "/home/runner/app/lib/resource_list.rb:100: warning: Passing the keyword argument as the last hash parameter is OK thanks", fake_reporter.first[:message]
+  end
 end


### PR DESCRIPTION
Strips the preamble from the Ruby deprecation warning to de-dup messages:

    /home/runner/work/someapp/app/models/conference_assignment/assignment.rb:20: warning: …

Will clean up stuff like this:

![Screenshot 2023-11-21 at 17 14 26](https://github.com/Own-and-Ship/oas_agent/assets/9440/ae0292f3-97e8-4a9d-8285-72a80b7d9f2f)
