### PR TITLE
Swap `options = {}` to positional arguments

### DIFF
--- a/lib/agent/agent.rb
+++ b/lib/agent/agent.rb
@@ -37,7 +37,7 @@ module OasAgent
       def start
         @reporter = Reporter.instance
         @receiver = Receiver.new(@reporter, Rails.root.expand_path.to_s)
-        @ruby_receiver = RubyReceiver.new(reporter: @reporter, root: Rails.root.expand_path.to_s)
+        @ruby_receiver = RubyReceiver.new(@reporter, Rails.root.expand_path.to_s)
       end
     end
   end

--- a/lib/agent/agent.rb
+++ b/lib/agent/agent.rb
@@ -36,7 +36,7 @@ module OasAgent
 
       def start
         @reporter = Reporter.instance
-        @receiver = Receiver.new(reporter: @reporter, root: Rails.root.expand_path.to_s)
+        @receiver = Receiver.new(@reporter, Rails.root.expand_path.to_s)
         @ruby_receiver = RubyReceiver.new(reporter: @reporter, root: Rails.root.expand_path.to_s)
       end
     end

--- a/lib/agent/event_cache.rb
+++ b/lib/agent/event_cache.rb
@@ -14,11 +14,13 @@ module OasAgent
         counts: 6
       }.freeze
 
-      def self.hash_for_event_data(options = {})
-        Digest::SHA256.hexdigest(
-          options.fetch(:callstack).join("") + options.fetch(:message) + options.fetch(:software) + \
-            options.fetch(:version) + options.fetch(:program_root)
-        )
+      # @param message [String]
+      # @param software [String]
+      # @param version [String]
+      # @param callstack [Array<String>]
+      # @param program_root [String]
+      def self.hash_for_event_data(message, software, version, callstack, program_root)
+        Digest::SHA256.hexdigest(callstack.join("") + message + software + version + program_root)
       end
 
       def initialize(event_hash, message, software, software_version, callstack, program_root)

--- a/lib/agent/events_cache.rb
+++ b/lib/agent/events_cache.rb
@@ -15,7 +15,7 @@ module OasAgent
       end
 
       def add_event(message, software, version, callstack)
-        eh = EventCache.hash_for_event_data(message: message, software: software, version: version, callstack: callstack, program_root: @program_root)
+        eh = EventCache.hash_for_event_data(message, software, version, callstack, @program_root)
 
         if !@events.has_key?(eh)
           @events[eh] = EventCache.new(eh, message, software, version, callstack, @program_root)

--- a/lib/agent/events_cache.rb
+++ b/lib/agent/events_cache.rb
@@ -9,8 +9,9 @@ require "base64"
 module OasAgent
   module Agent
     class EventsCache
-      def initialize(options = {})
-        @program_root = options.fetch(:program_root)
+      # @param program_root [String]
+      def initialize(program_root)
+        @program_root = program_root
         @events = {}
       end
 

--- a/lib/agent/receiver.rb
+++ b/lib/agent/receiver.rb
@@ -6,9 +6,11 @@ require "agent/configuration/manager"
 module OasAgent
   module Agent
     class Receiver
-      def initialize(options = {})
-        @reporter = options.fetch(:reporter)
-        @rails_root = options.fetch(:root)
+      # @param reporter [Agent::Reporter]
+      # @param rails_root [String]
+      def initialize(reporter, rails_root)
+        @reporter = reporter
+        @rails_root = rails_root
         @rails_version = Rails::VERSION::STRING
       end
 

--- a/lib/agent/reporter.rb
+++ b/lib/agent/reporter.rb
@@ -22,8 +22,9 @@ module OasAgent
         @reporter_thread = create_reporter_thread unless OasAgent::AgentContext.config[:reporter][:send_immediately]
       end
 
-      def push(data, options = {})
-        non_block = options.fetch(:non_block, true)
+      # @param data [Object]
+      # @param non_block [Boolean] Whether to block if the queue is full
+      def push(data, non_block = true)
         @report_queue.push(data, non_block)
 
         if OasAgent::AgentContext.config[:reporter][:send_immediately]

--- a/lib/agent/reporter.rb
+++ b/lib/agent/reporter.rb
@@ -58,7 +58,7 @@ module OasAgent
       end
 
       def receive_reports_from_queue
-        @event_cache = OasAgent::Agent::EventsCache.new(program_root: @rails_root)
+        @event_cache = OasAgent::Agent::EventsCache.new(@rails_root)
 
         # Let's block waiting for the first report to send. This way we avoid
         # looping over an empty reports to send list and throwing a timeout

--- a/lib/agent/ruby_receiver.rb
+++ b/lib/agent/ruby_receiver.rb
@@ -7,9 +7,11 @@ require "singleton"
 module OasAgent
   module Agent
     class RubyReceiver
-      def initialize(options = {})
-        @reporter = options.fetch(:reporter)
-        @rails_root = options.fetch(:root)
+      # @param reporter [OasAgent::Agent::Reporter]
+      # @param rails_root [String]
+      def initialize(reporter, rails_root)
+        @reporter = reporter
+        @rails_root = rails_root
       end
 
       def push(message, callstack)

--- a/test/lib/agent/event_cache_test.rb
+++ b/test/lib/agent/event_cache_test.rb
@@ -27,6 +27,6 @@ class OasAgentRubyEventCacheTest < Minitest::Test
 
   def test_hash_for_event_data
     assert_equal "f2fa641a7c6d5beb6f7984678d95e06a1e057ae9e50b0c4eadd8c238942d506c",
-      OasAgent::Agent::EventCache.hash_for_event_data(message: "some message", software: "ruby", version: "1.2.3.4", callstack: ["a", "b", "c"], program_root: "/some/program/root")
+      OasAgent::Agent::EventCache.hash_for_event_data("some message", "ruby", "1.2.3.4", ["a", "b", "c"], "/some/program/root")
   end
 end

--- a/test/lib/agent/events_cache_test.rb
+++ b/test/lib/agent/events_cache_test.rb
@@ -14,14 +14,14 @@ class OasAgentRubyEventsCacheTest < Minitest::Test
   end
 
   def test_maintains_a_count_of_similar_events
-    event_cache = OasAgent::Agent::EventsCache.new(program_root: "/some/root")
+    event_cache = OasAgent::Agent::EventsCache.new("/some/root")
     event_cache.add_event("Some deprecation message", "Ruby", "9000", ["a", "b"])
     event_cache.add_event("Some deprecation message", "Ruby", "9000", ["a", "b"])
     assert_equal 2, deserialize_event_cache(event_cache.serializable).first[OasAgent::Agent::EventCache::DATA_INDEXES[:counts]]
   end
 
   def test_counts_separate_software_versions_separately
-    event_cache = OasAgent::Agent::EventsCache.new(program_root: "/some/root")
+    event_cache = OasAgent::Agent::EventsCache.new("/some/root")
     event_cache.add_event("Some deprecation message", "Ruby", "9000", ["a", "b"])
     event_cache.add_event("Some deprecation message", "Ruby", "9000", ["a", "b"])
 
@@ -32,7 +32,7 @@ class OasAgentRubyEventsCacheTest < Minitest::Test
   end
 
   def test_maintains_separate_counts_of_distinct_events
-    event_cache = OasAgent::Agent::EventsCache.new(program_root: "/some/root")
+    event_cache = OasAgent::Agent::EventsCache.new("/some/root")
     event_cache.add_event("Some deprecation message", "Ruby", "9000", ["a", "b"])
     event_cache.add_event("Some deprecation message", "Ruby", "9000", ["a", "b"])
 
@@ -56,7 +56,7 @@ class OasAgentRubyEventsCacheTest < Minitest::Test
   end
 
   def test_it_knows_the_number_of_events_it_contains
-    event_cache = OasAgent::Agent::EventsCache.new(program_root: "/some/root")
+    event_cache = OasAgent::Agent::EventsCache.new("/some/root")
     event_cache.add_event("Some deprecation message", "Ruby", "9000", ["a", "b"])
     event_cache.add_event("Some deprecation message", "Ruby", "9000", ["a", "b"])
 

--- a/test/lib/agent/ruby_receiver_test.rb
+++ b/test/lib/agent/ruby_receiver_test.rb
@@ -6,7 +6,7 @@ require "agent/agent"
 class OasAgentRubyReceiverTest < Minitest::Test
   def test_leaves_messages_it_doesnt_recognise_unchanged
     fake_reporter = []
-    r = OasAgent::Agent::RubyReceiver.new(reporter: fake_reporter, root: "/a/b/c")
+    r = OasAgent::Agent::RubyReceiver.new(fake_reporter, "/a/b/c")
     r.push("/home/runner/app/lib/resource_list.rb:100: info: Passing the keyword argument as the last hash parameter is OK thanks", ["a", "b"])
     assert_equal "/home/runner/app/lib/resource_list.rb:100: info: Passing the keyword argument as the last hash parameter is OK thanks", fake_reporter.first[:message]
   end
@@ -27,7 +27,7 @@ class OasAgentRubyReceiverTest < Minitest::Test
     ]
 
     fake_reporter = []
-    r = OasAgent::Agent::RubyReceiver.new(reporter: fake_reporter, root: "/home/runner/work/someapp")
+    r = OasAgent::Agent::RubyReceiver.new(fake_reporter, "/home/runner/work/someapp")
     r.push(deprecation_message, callstack)
     assert_equal expected_message, fake_reporter.first[:message]
   end


### PR DESCRIPTION
Fixes #27 by swapping us from faking keyword arguments (with hardly any of the upsides) with hashes to just using good old positional arguments.

Also decorated the updated methods with seemingly accurate YARD Docs, although I'm not convinced they really add much yet.