### PR TITLE
Avoid nil#+ being called in EventCache

### DIFF
--- a/lib/agent/event_cache.rb
+++ b/lib/agent/event_cache.rb
@@ -16,8 +16,7 @@ module OasAgent
 
       def self.hash_for_event_data(options = {})
         Digest::SHA256.hexdigest(
-          options.fetch(:callstack).join("") + options.fetch(:message) + options.fetch(:software) + \
-            options.fetch(:version) + options.fetch(:program_root)
+          "#{options.fetch(:callstack).join('')}#{options.fetch(:message)}#{options.fetch(:software)}#{options.fetch(:version)}#{options.fetch(:program_root)}"
         )
       end
 

--- a/test/lib/agent/event_cache_test.rb
+++ b/test/lib/agent/event_cache_test.rb
@@ -29,4 +29,8 @@ class OasAgentRubyEventCacheTest < Minitest::Test
     assert_equal "f2fa641a7c6d5beb6f7984678d95e06a1e057ae9e50b0c4eadd8c238942d506c",
       OasAgent::Agent::EventCache.hash_for_event_data(message: "some message", software: "ruby", version: "1.2.3.4", callstack: ["a", "b", "c"], program_root: "/some/program/root")
   end
+
+  def test_hash_for_event_data_with_nil_inputs
+    assert_equal "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", OasAgent::Agent::EventCache.hash_for_event_data(callstack: [], message: nil, software: nil, version: nil, program_root: nil)
+  end
 end


### PR DESCRIPTION
Originally reported in #3 

Not sure which of these can return `nil`, but have observed it throwing a TypeError on both Ruby 2.7.5 and Ruby 3.1.4 now from running gem sha 9287b6388abf913f723870ed07819cbe4811ff00.

Implicitly convert everything to a string to stop this happening.