### PR TITLE
Enable deprecations where they are disabled

### DIFF
--- a/lib/agent/configuration/default_source.rb
+++ b/lib/agent/configuration/default_source.rb
@@ -9,11 +9,9 @@ module OasAgent
       class DefaultSource
         def to_h
           {
-            common: {
-              log_level: :info,
-              report_ruby_deprecations: true,
-              suppress_ruby_warnings: true
-            },
+            log_level: :info,
+            report_ruby_deprecations: true,
+            suppress_ruby_warnings: true,
             api: {
               host: "ownandship.io",
               port: 443,

--- a/lib/control/instance_methods.rb
+++ b/lib/control/instance_methods.rb
@@ -13,6 +13,16 @@ module OasAgent
       def init(options={})
         env = determine_env(options)
 
+        # At some point this got flipped to false by default in Rails for
+        # production environments, but it breaks deprecation reporting for Own &
+        # Ship so set it to true.
+        if options[:config].active_support.respond_to? :report_deprecations
+          if !options[:config].active_support.report_deprecations
+            logger.warning "Deprecation reporting is turned off (`config.active_support.report_deprecations = false`) but Own & Ship requires deprecation reporting to be enabled to work. We are enabling the setting for you."
+          end
+          options[:config].active_support.report_deprecations = true
+        end
+
         OasAgent::AgentContext.logger = OasAgent::Agent::Logger.new
         OasAgent::AgentContext.agent = OasAgent::Agent::Base.instance
 

--- a/lib/control/instance_methods.rb
+++ b/lib/control/instance_methods.rb
@@ -31,7 +31,7 @@ module OasAgent
         end
 
         start_agent
-        insert_ruby_deprecation_behaviour if OasAgent::AgentContext.config[:common][:report_ruby_deprecations] == true
+        insert_ruby_deprecation_behaviour if OasAgent::AgentContext.config[:report_ruby_deprecations] == true
         insert_deprecation_behaviour
       end
 

--- a/lib/control/ruby_reporting.rb
+++ b/lib/control/ruby_reporting.rb
@@ -6,7 +6,7 @@ module ::Warning
     alias :original_warn :warn
 
     def warn(warning)
-      original_warn(warning) unless OasAgent::AgentContext.config[:common][:suppress_ruby_warnings]
+      original_warn(warning) unless OasAgent::AgentContext.config[:suppress_ruby_warnings]
       OasAgent::AgentContext.agent.ruby_receiver.push(warning.strip, caller) if warning.include?("deprecated")
     end
   end


### PR DESCRIPTION
We need to add tests for this, but those will come when we implement integration tests with different Rails versions later.