### PR TITLE
Support all rails warnings in Rails 7.1+

### DIFF
--- a/lib/control/instance_methods.rb
+++ b/lib/control/instance_methods.rb
@@ -62,14 +62,16 @@ module OasAgent
       end
 
       def insert_deprecation_behaviour
-        ActiveSupport::Deprecation.behavior << OasAgent::AgentContext.agent.receiver
-
-        # Rails >= 7.1
+        # Rails >= 7.1 has individual deprecators per rails gem, wrapped into a nice collection. We only inject into
+        # those now, anything using the old API will still be emitted.
         if Rails.application.respond_to?(:deprecators)
-          # Using deprecators#behavior= overrides existing behaviors, add ourselves instead
-          Rails.application.deprecators.each do |deprecator|
-            deprecator.behavior << OasAgent::AgentContext.agent.receiver
-          end
+          # We need to go through #behavior= to be applied to all existing and future deprecators, but maintain the
+          # existing behavior as we did in older versions of rails
+          existing_behavior = Rails.application.deprecators.instance_variable_get(:@options)[:behavior]
+          Rails.application.deprecators.behavior = [existing_behavior, OasAgent::AgentContext.agent.receiver]
+        else
+          # There's only one way to raise deprecations, just hook it
+          ActiveSupport::Deprecation.behavior << OasAgent::AgentContext.agent.receiver
         end
       end
 

--- a/lib/control/instance_methods.rb
+++ b/lib/control/instance_methods.rb
@@ -63,6 +63,14 @@ module OasAgent
 
       def insert_deprecation_behaviour
         ActiveSupport::Deprecation.behavior << OasAgent::AgentContext.agent.receiver
+
+        # Rails >= 7.1
+        if Rails.application.respond_to?(:deprecators)
+          # Using deprecators#behavior= overrides existing behaviors, add ourselves instead
+          Rails.application.deprecators.each do |deprecator|
+            deprecator.behavior << OasAgent::AgentContext.agent.receiver
+          end
+        end
       end
 
       def insert_ruby_deprecation_behaviour


### PR DESCRIPTION
## What?

- [x] Inject into the new deprecators in Rails 7.1+
- [x] Junction passes on Rails 7.1
- [x] Tested against older versions of Rails

## Why?

ActiveSupport has moved from having a singleton `Deprecation` instance that everything gets reported through, to having a collection of deprecators which Rails is setting up at `Rails.application.deprecators` during boot. Each of the rails gems then has a deprecator instance in that collection, so we need to inject our receiver into each of those to get all warnings out of the app still.

We'll miss anything emitted before oas_agent is injected, but that's existing behaviour so ignoring that for now.