### PR TITLE
Upgrade minitest to 5.20.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
     ast (2.4.2)
     json (2.6.3)
     language_server-protocol (3.17.0.3)
-    minitest (5.13.0)
+    minitest (5.20.0)
     msgpack (1.7.2)
     parallel (1.23.0)
     parser (3.2.2.4)


### PR DESCRIPTION
Anything earlier doesn't support Ruby 3.3.0