### PR TITLE
Stop us assigning nil to deprecators behaviour

### DIFF
--- a/lib/control/instance_methods.rb
+++ b/lib/control/instance_methods.rb
@@ -68,7 +68,11 @@ module OasAgent
           # We need to go through #behavior= to be applied to all existing and future deprecators, but maintain the
           # existing behavior as we did in older versions of rails
           existing_behavior = Rails.application.deprecators.instance_variable_get(:@options)[:behavior]
-          Rails.application.deprecators.behavior = [existing_behavior, OasAgent::AgentContext.agent.receiver]
+          # Rails will raise an error if either of these don't respond correctly so be careful
+          Rails.application.deprecators.behavior = [
+            existing_behavior,
+            OasAgent::AgentContext.agent.receiver
+          ].compact
         else
           # There's only one way to raise deprecations, just hook it
           ActiveSupport::Deprecation.behavior << OasAgent::AgentContext.agent.receiver

--- a/test/lib/control/instance_method_test.rb
+++ b/test/lib/control/instance_method_test.rb
@@ -1,0 +1,61 @@
+require "test_helper"
+
+class InstanceMethodTest < Minitest::Test
+  # Fake out from a test purpose how Rails 7.1 works with deprecations
+  # This only mimics, not a full implementation
+  class MimicRails
+    class Deprecators < Array
+      attr_reader :options
+
+      def initialize(options)
+        @options = options
+      end
+
+      def behavior=(obj_or_array)
+        Array(obj_or_array).each do |obj|
+          raise "Cannot be nil" unless obj
+        end
+        @options[:behavior] = Array(obj_or_array)
+      end
+    end
+
+    def self.application
+      @application ||= new
+    end
+
+    attr_accessor :deprecators
+  end
+
+  def setup
+    Object.const_set(:Rails, MimicRails)
+  end
+
+  def teardown
+    Object.__send__(:remove_const, :Rails) if Object.const_defined?(:Rails)
+  end
+
+  def test_insert_deprecation_behaviour_rails_71_existing_behaviour
+    MimicRails.application.deprecators = MimicRails::Deprecators.new(behavior: :raise)
+
+    OasAgent::AgentContext.agent = OasAgent::Agent::Base.instance
+    OasAgent::AgentContext.agent.instance_variable_set(:@receiver, Object.new)
+
+    OasAgent::Control.instance.__send__(:insert_deprecation_behaviour)
+
+    assert_equal [:raise, OasAgent::AgentContext.agent.receiver], MimicRails.application.deprecators.options[:behavior]
+  end
+
+  def test_insert_deprecation_behaviour_rails_71_nil_behaviour
+    MimicRails.application.deprecators = MimicRails::Deprecators.new(behavior: nil)
+    Object.const_set(:Rails, MimicRails)
+
+    OasAgent::AgentContext.agent = OasAgent::Agent::Base.instance
+    OasAgent::AgentContext.agent.instance_variable_set(:@receiver, Object.new)
+
+    OasAgent::Control.instance.__send__(:insert_deprecation_behaviour)
+
+    assert_equal [OasAgent::AgentContext.agent.receiver], MimicRails.application.deprecators.options[:behavior]
+  ensure
+    Object.__send__(:remove_const, :Rails)
+  end
+end


### PR DESCRIPTION
Only affects Rails >= 7.1, and only if nothing is configured for `Rails.application.config.*.deprecations*` settings.

Rails checks the object(s) assigned to behaviour respond appropriately, and `nil` doesn't. If we get back a `nil` from the deprecator options, we need to compact it before setting the behaviour for all.