### PR TITLE
Depend on base64 for newer rubies

### DIFF
--- a/gemfiles/Gemfile.ruby-3.3.rb.lock
+++ b/gemfiles/Gemfile.ruby-3.3.rb.lock
@@ -2,11 +2,13 @@ PATH
   remote: ..
   specs:
     oas_agent (0.0.1)
+      base64
       msgpack
 
 GEM
   remote: https://rubygems.org/
   specs:
+    base64 (0.2.0)
     minitest (5.20.0)
     msgpack (1.7.2)
     rake (13.1.0)

--- a/oas_agent.gemspec
+++ b/oas_agent.gemspec
@@ -34,6 +34,11 @@ Gem::Specification.new do |spec|
   # the environment the gem is runnign in.
   spec.add_dependency "msgpack"
 
+  # Older rubies shipped these in stdlib, newer ones need the dependency
+  if "3.3.0" <= RUBY_VERSION
+    spec.add_dependency "base64"
+  end
+
   # Development dependencies must be version specced to work from Ruby 1.9.3 up to Ruby head
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
## What?

- [x] Add dependency for `base64` in gemspec for newer rubies

## Why?

Ruby is moving certain libraries out of the stdlib into bundled gems, and therefore needs a dependency on them in our dependencies, rather than just magically being available. Ruby 3.3.0 is emitting a warning for us requiring base64 now without having it in the dependencies first.

Naturally the base64 gem doesn't work on Rubies older than 2.4.0, so we can't just depend on it in the gemspec and be done with it. Instead lets depend on it for Ruby 3.3 or newer.
