### PR TITLE
Start testing on Ruby 3.4

### DIFF
--- a/.github/workflows/test_ruby.yml
+++ b/.github/workflows/test_ruby.yml
@@ -31,6 +31,7 @@ jobs:
           - "3.1"
           - "3.2"
           - "3.3"
+          - "3.4"
     steps:
       - name: Clone project
         uses: actions/checkout@v3

--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,7 @@ RSpec::Core::RakeTask.new(:spec)
 SUPPORTED_RUBY_VERSIONS = [
   "1.9.3", "2.0.0",
   "2.1.10", "2.2.10", "2.3.8", "2.4.10", "2.5.9", "2.6.10", "2.7.8",
-  "3.0.7", "3.1.6", "3.2.5", "3.3.5"
+  "3.0.7", "3.1.6", "3.2.5", "3.3.5", "3.4.0-preview2"
 ]
 
 desc "Build all ruby version Docker images"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,3 +131,13 @@ services:
     volumes:
     - ".:/app"
     working_dir: "/app"
+  ruby-3-4-0-preview2:
+    build:
+      context: "."
+      dockerfile: Dockerfile
+      args:
+        RUBY_VERSION: 3.4.0-preview2
+        BUNDLE_GEMFILE: gemfiles/Gemfile.ruby-3.4.rb
+    volumes:
+    - ".:/app"
+    working_dir: "/app"

--- a/gemfiles/Gemfile.ruby-3.4.rb
+++ b/gemfiles/Gemfile.ruby-3.4.rb
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec path: "../"

--- a/gemfiles/Gemfile.ruby-3.4.rb.lock
+++ b/gemfiles/Gemfile.ruby-3.4.rb.lock
@@ -1,0 +1,46 @@
+PATH
+  remote: ..
+  specs:
+    oas_agent (0.0.1)
+      base64
+      logger
+      msgpack
+      ostruct
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    base64 (0.2.0)
+    diff-lcs (1.5.1)
+    logger (1.6.1)
+    minitest (5.25.1)
+    msgpack (1.7.3)
+    ostruct (0.6.0)
+    rake (13.2.1)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.2)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.1)
+
+PLATFORMS
+  aarch64-linux
+  ruby
+
+DEPENDENCIES
+  bundler
+  minitest (~> 5.0)
+  oas_agent!
+  rake
+  rspec (~> 3.0)
+
+BUNDLED WITH
+   2.5.22


### PR DESCRIPTION
## What?

- [x] Add Ruby 3.4.0-preview2 to the test suite

## Why?

We're expecting Ruby 3.4.0 to come out on December 25th, but we can start testing against the preview release to ensure nothing is broken ahead of it dropping.

We already add dependencies on the now-bundled-previously-standard gems in 3.4.0, so there's nothing more to change to support it. 🎉 