### PR TITLE
`Reporter#restart` restarts the reporter threads

### DIFF
--- a/lib/agent/reporter.rb
+++ b/lib/agent/reporter.rb
@@ -33,6 +33,14 @@ module OasAgent
         end
       end
 
+      # Expects to be called after a process has forked to restart now-dead thread
+      def restart
+        self.class.instance_variable_get(:@singleton__mutex__).synchronize do
+          @reporter_thread.kill if @reporter_thread.alive?
+          @reporter_thread = create_reporter_thread
+        end
+      end
+
       private
 
       # The agent batches reports and sends them when we have reached either the

--- a/oas_agent.gemspec
+++ b/oas_agent.gemspec
@@ -38,6 +38,10 @@ Gem::Specification.new do |spec|
   if "3.3.0" <= RUBY_VERSION
     spec.add_dependency "base64"
   end
+  if "3.4.0" <= RUBY_VERSION
+    spec.add_dependency "logger"
+    spec.add_dependency "ostruct"
+  end
 
   # Development dependencies must be version specced to work from Ruby 1.9.3 up to Ruby head
   spec.add_development_dependency "bundler"

--- a/test/lib/agent/reporter_test.rb
+++ b/test/lib/agent/reporter_test.rb
@@ -73,4 +73,31 @@ class OasAgentAgentReporterTest < Minitest::Test
 
     slow_thread.kill
   end
+
+  def test_no_background_thread_when_send_immediately
+    OasAgent::AgentContext.config.integrate({reporter: {send_immediately: true}})
+
+    TestReporter.instance
+    assert_nil TestReporter.instance.instance_variable_get(:@reporter_thread)
+  end
+
+  def test_close_with_send_immediately
+    OasAgent::AgentContext.config.integrate({reporter: {send_immediately: true}})
+
+    TestReporter.instance.close
+
+    assert_nil TestReporter.instance.instance_variable_get(:@reporter_thread)
+    q = TestReporter.instance.instance_variable_get(:@report_queue)
+    if q.respond_to?(:closed)
+      assert q.closed?, "Reporter report queue should be closed"
+    end
+  end
+
+  def test_restart_with_send_immediately
+    OasAgent::AgentContext.config.integrate({reporter: {send_immediately: true}})
+
+    TestReporter.instance.restart
+
+    assert_nil TestReporter.instance.instance_variable_get(:@reporter_thread)
+  end
 end

--- a/test/lib/agent/reporter_test.rb
+++ b/test/lib/agent/reporter_test.rb
@@ -10,16 +10,62 @@ class OasAgentAgentReporterTest < Minitest::Test
 
     # Ensure we have default config in place
     OasAgent::AgentContext.config.integrate(OasAgent::Agent::Configuration::DefaultSource.new.to_h)
+
+    # Load the reporter in an isolated way
+    Object.const_set(:TestReporter, Class.new(OasAgent::Agent::Reporter))
   end
 
   def teardown
+    # Stop the temporary reporter
+    TestReporter.instance.close
+    Object.__send__(:remove_const, :TestReporter) if defined?(Reporter)
+
     # Remove the "stub"
     Object.__send__(:remove_const, :Rails) if defined?(Rails)
   end
 
   def test_instance_returns_same_object
-    first = OasAgent::Agent::Reporter.instance
-    second = OasAgent::Agent::Reporter.instance
-    assert_equal first.object_id, second.object_id
+    object1 = TestReporter.instance
+    object2 = TestReporter.instance
+
+    assert_equal object1.object_id, object2.object_id
+  end
+
+  def test_close_shuts_down_thread
+    thread = TestReporter.instance.instance_variable_get(:@reporter_thread)
+    queue = TestReporter.instance.instance_variable_get(:@report_queue)
+
+    TestReporter.instance.close
+
+    assert queue.closed?, "Reporter report queue should be closed"
+    refute thread.alive?, "Reporter thread should not be alive"
+  end
+
+  def test_close_shuts_down_slow_thread
+    logger = Class.new do
+      def messages
+        @messages ||= []
+      end
+
+      def warn(message)
+        self.messages << [:warn, message]
+      end
+    end
+
+    OasAgent::AgentContext.logger = logger.new
+
+    # Stop us leaking the original thread in test
+    TestReporter.instance.instance_variable_get(:@reporter_thread).kill
+
+    # Add a slow thread
+    slow_thread = Thread.new { sleep 10 }
+    TestReporter.instance.instance_variable_set(:@reporter_thread, slow_thread)
+
+    TestReporter.instance.close
+
+    assert_equal [[:warn, "Timeout joining report thread during shutdown"]], OasAgent::AgentContext.logger.messages
+    assert TestReporter.instance.instance_variable_get(:@report_queue).closed?, "Reporter report queue should be closed"
+
+    slow_thread.kill
   end
 end

--- a/test/lib/agent/reporter_test.rb
+++ b/test/lib/agent/reporter_test.rb
@@ -37,7 +37,9 @@ class OasAgentAgentReporterTest < Minitest::Test
 
     TestReporter.instance.close
 
-    assert queue.closed?, "Reporter report queue should be closed"
+    if queue.respond_to?(:closed)
+      assert queue.closed?, "Reporter report queue should be closed"
+    end
     refute thread.alive?, "Reporter thread should not be alive"
   end
 
@@ -64,7 +66,10 @@ class OasAgentAgentReporterTest < Minitest::Test
     TestReporter.instance.close
 
     assert_equal [[:warn, "Timeout joining report thread during shutdown"]], OasAgent::AgentContext.logger.messages
-    assert TestReporter.instance.instance_variable_get(:@report_queue).closed?, "Reporter report queue should be closed"
+    q = TestReporter.instance.instance_variable_get(:@report_queue)
+    if q.respond_to?(:closed)
+      assert q.closed?, "Reporter report queue should be closed"
+    end
 
     slow_thread.kill
   end

--- a/test/lib/agent/reporter_test.rb
+++ b/test/lib/agent/reporter_test.rb
@@ -1,4 +1,25 @@
 require "test_helper"
+require "support/mock_rails"
 
-class OasAgentRubyReceiverTest < Minitest::Test
+class OasAgentAgentReporterTest < Minitest::Test
+
+  def setup
+    # Stub it out and make sure it's reset before each test
+    Object.const_set(:Rails, MockRails)
+    MockRails.reset
+
+    # Ensure we have default config in place
+    OasAgent::AgentContext.config.integrate(OasAgent::Agent::Configuration::DefaultSource.new.to_h)
+  end
+
+  def teardown
+    # Remove the "stub"
+    Object.__send__(:remove_const, :Rails) if defined?(Rails)
+  end
+
+  def test_instance_returns_same_object
+    first = OasAgent::Agent::Reporter.instance
+    second = OasAgent::Agent::Reporter.instance
+    assert_equal first.object_id, second.object_id
+  end
 end

--- a/test/support/mock_rails.rb
+++ b/test/support/mock_rails.rb
@@ -47,6 +47,6 @@ module MockRails
   end
 
   def root
-    Pathname.new(__dir__).join("..", "tmp").expand_path
+    Pathname.new(__FILE__).dirname.join("..", "tmp").expand_path
   end
 end


### PR DESCRIPTION
## What?

- [x] Detect process change and restart reporter thread (broadly lifted from #55)
- [x] Implement deep merge for configuration loading
- [x] Implement hash key symbolisation for configuration loading
- [x] Implement queue closing behaviour for Ruby < 2.3
- [x] Fix use of `__dir__` for older rubies from #57 
- [x] Add more previously-default gems to gemspec for Ruby >= 3.4

## Why?

Ruby process forking only keeps the currently active thread active, all other threads end up dead. This includes the OasAgent reporter background thread, so we won't send reports post-fork. Given Puma and Unicorn trigger this behaviour, that is not ideal.

We now attempt to detect at the point of publishing a report when the process has changed, or if the reporter thread isn't currently running and start it again if needed. Given we could have multiple threads reporting deprecations "concurrently", gate this logic with the mutex from Singleton in the reporter.

If we need to restart the Reporter thread at any point, we can also now call `Reporter#restart` to do so thread-safely as well.

Adding more tests for the Reporter class exposed the `SizedQueue` class only learned how to be closed in Ruby 2.3 onwards. We only expect there to be one consumer, so "fake" it by pushing a specific object into the queue, and then checking the result. (Turns out you can break out of a loop in parent method by `raise StopIteration` which is a neat trick.)

Also adding more tests exposed us leaning on ActiveSupport without intending to, which has been replaced by teaching the config Manager to deep merge & symbolise keys directly.

Fixes #52