### PR TITLE
Remove accidental ActiveSupport dependency

### DIFF
--- a/lib/agent/configuration/manager.rb
+++ b/lib/agent/configuration/manager.rb
@@ -18,7 +18,25 @@ module OasAgent
         end
 
         def integrate(config)
-          @config.deep_merge!(config.deep_symbolize_keys)
+          @config = deep_merge(@config, deep_symbolize(config))
+        end
+
+        def deep_merge(left, right)
+          left.merge(right) do |key, left_val, right_val|
+            if left_val.is_a?(Hash) && right_val.is_a?(Hash)
+              deep_merge(left_val, right_val)
+            else
+              right_val
+            end
+          end
+        end
+
+        def deep_symbolize(hash)
+          hash.each_with_object({}) do |(key, val), new_hash|
+            new_key = key.respond_to?(:to_sym) ? key.to_sym : key
+            new_val = val.is_a?(Hash) ? deep_symbolize(val) : val
+            new_hash[new_key] = new_val
+          end
         end
       end
     end

--- a/test/lib/agent/configuration/manager_test.rb
+++ b/test/lib/agent/configuration/manager_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "support/mock_rails"
+
+class ManagerTest < Minitest::Test
+  def setup
+    # Stub it out and make sure it's reset before each test
+    Object.const_set(:Rails, MockRails)
+    MockRails.reset
+  end
+
+  def teardown
+    # Remove the "stub"
+    Object.__send__(:remove_const, :Rails) if defined?(Rails)
+  end
+
+  def test_integrate
+    # Simple merge
+    simple = OasAgent::Agent::Configuration::Manager.new
+    simple.integrate({ "log_level" => "info" })
+    assert_equal "info", simple[:log_level], "Should have symbolized key stored"
+
+    # Deep merge replacing empty key
+    merge_empty = OasAgent::Agent::Configuration::Manager.new
+    merge_empty.integrate({ "development" => { "report_immediately" => true } })
+    assert_equal true, merge_empty[:development][:report_immediately], "Should have symbolized hash stored"
+
+    # Deep merge replacing existing key
+    merge_replace = OasAgent::Agent::Configuration::Manager.new
+    merge_replace.integrate({"development" => "enabled"})
+    merge_replace.integrate({ "development" => { "report_immediately" => true } })
+    assert_equal true, merge_replace[:development][:report_immediately], "Should replace string value with symbolized hash"
+  end
+end

--- a/test/lib/oas_agent/railtie_test.rb
+++ b/test/lib/oas_agent/railtie_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "ostruct"
 require "support/mock_rails"
 
 class RailtieTest < Minitest::Test

--- a/test/lib/oas_agent/railtie_test.rb
+++ b/test/lib/oas_agent/railtie_test.rb
@@ -1,29 +1,7 @@
 require "test_helper"
+require "support/mock_rails"
 
 class RailtieTest < Minitest::Test
-  # Our only goal here is to let the railtie load & call `.initializer` where we can access it
-  module MockRails
-    module VERSION
-      MAJOR = 7
-    end
-
-    class Railtie
-      def self.initializer(name, options = {}, &block)
-        MockRails.initializers[name] = {options: options, block: block}
-      end
-    end
-
-    module_function
-
-    def initializers
-      @initializers ||= {}
-    end
-
-    def reset
-      @initializers = nil
-    end
-  end
-
   def setup
     # Stub it out and make sure it's reset before each test
     Object.const_set(:Rails, MockRails)

--- a/test/support/mock_rails.rb
+++ b/test/support/mock_rails.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "pathname"
+
+# Lets us mock out Rails without having to load it all in our tests.
+#
+# To setup your test class to use this, ensure you set/unset the constant Rails, eg
+#
+#     def setup
+#       # Stub it out and make sure it's reset before each test
+#       Object.const_set(:Rails, MockRails)
+#       MockRails.reset
+#     end
+#
+#     def teardown
+#       # Remove the "stub"
+#       Object.__send__(:remove_const, :Rails) if defined?(Rails)
+#     end
+#
+module MockRails
+  module VERSION
+    MAJOR = 7
+  end
+
+  class Railtie
+    def self.initializer(name, options = {}, &block)
+      MockRails.initializers[name] = {options: options, block: block}
+    end
+  end
+
+  module_function
+
+  def initializers
+    @initializers ||= {}
+  end
+
+  def reset
+    @initializers = nil
+  end
+
+  def env
+    @env ||= "test"
+  end
+
+  def env=(value)
+    @env = value
+  end
+
+  def root
+    Pathname.new(__dir__).join("..", "tmp").expand_path
+  end
+end


### PR DESCRIPTION
## What?

- [x] Implement hash deep_merge in config manager
- [x] Implement hash key symbolisation in config manager

## Why?

We were leaning on ActiveSupport being available - which is fine in rails apps - but not when writing tests. We don't want the dependency on ActiveSupport.

Fixes #56 