### PR TITLE
Update User-Agent header sent in requests

### DIFF
--- a/lib/agent/configuration/default_source.rb
+++ b/lib/agent/configuration/default_source.rb
@@ -1,8 +1,6 @@
 # encoding: utf-8
 # frozen_string_literal: true
 
-require "agent/version"
-
 module OasAgent
   module Agent
     module Configuration
@@ -24,7 +22,6 @@ module OasAgent
               reports_encoding: "identity",
               reports_content_type: "application/json",
               reports_request_path: "/api/report/deprecation",
-              user_agent: "Own & Serve Ruby agent [version #{OasAgent::VERSION}]",
               min_data_size_for_compress_bytes: 64 * 1024, # 64kB,
               max_data_size_for_post_bytes: 10 * 1024 * 1024, # 10 MB, no particular reason other than seems reasonable without being so large that it's too much overhead
               max_retries_per_record: 3

--- a/lib/agent/connection.rb
+++ b/lib/agent/connection.rb
@@ -3,6 +3,7 @@
 
 require "net/https"
 require "json"
+require "agent/version"
 
 module OasAgent
   module Agent
@@ -17,6 +18,8 @@ module OasAgent
         (Net::OpenTimeout if defined?(Net::OpenTimeout)),
       ].compact.freeze
 
+      USER_AGENT = "oas-agent/#{OasAgent::VERSION} (ruby)".freeze
+
       def initialize
         @default_headers = {
           "Content-Encoding" => OasAgent::AgentContext.config[:api][:reports_encoding],
@@ -28,7 +31,7 @@ module OasAgent
 
       def send_request(data)
         request = Net::HTTP::Post.new(config[:api][:reports_request_path], @default_headers)
-        request["user-agent"] = config[:api][:user_agent]
+        request["user-agent"] = USER_AGENT
 
         request.content_type = config[:api][:reports_content_type]
 

--- a/spec/agent/connection_spec.rb
+++ b/spec/agent/connection_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe OasAgent::Agent::Connection do
     FakeWeb.register_uri(:post, "https://ownandship.test/api/report/deprecation",
       headers: {
         "X-Api-Token" => "test_key",
+        "User-Agent" => "oas-agent/#{OasAgent::VERSION} (ruby)",
       }
     )
 


### PR DESCRIPTION
## What?

- [x] Move User-Agent from Config to Constant and update/shorten format

## Why?

Fix #58 by changing the User-Agent we're sending. Shorten it (less on the wire) and ensure it follows a parseable format ([MDN docs on User-Agent](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent#library_and_net_tool_ua_strings)). We also don't need to change the User-Agent at runtime, so yoink it out of configuration and turn into a constant at boot. (Version is a constant too.)

Builds on #63 