### PR TITLE
Upgrade 3.3 ruby to 3.3.6

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,7 @@ RSpec::Core::RakeTask.new(:spec)
 SUPPORTED_RUBY_VERSIONS = [
   "1.9.3", "2.0.0",
   "2.1.10", "2.2.10", "2.3.8", "2.4.10", "2.5.9", "2.6.10", "2.7.8",
-  "3.0.7", "3.1.6", "3.2.5", "3.3.5", "3.4.0-preview2"
+  "3.0.7", "3.1.6", "3.2.5", "3.3.6", "3.4.0-preview2"
 ]
 
 desc "Build all ruby version Docker images"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,12 +121,12 @@ services:
     volumes:
     - ".:/app"
     working_dir: "/app"
-  ruby-3-3-5:
+  ruby-3-3-6:
     build:
       context: "."
       dockerfile: Dockerfile
       args:
-        RUBY_VERSION: 3.3.5
+        RUBY_VERSION: 3.3.6
         BUNDLE_GEMFILE: gemfiles/Gemfile.ruby-3.3.rb
     volumes:
     - ".:/app"


### PR DESCRIPTION
## What?

- [x] Replace Ruby 3.3.5 with 3.3.6 in local environment

## Why?

CI will already be using 3.3.6 as it automatically uses the latest patch release of every minor version.

This upgrades the local configuration to test on the latest patch release for the 3.3 version.