### PR TITLE
Implement EnvironmentSource without ActiveSupport

### DIFF
--- a/lib/agent/configuration/environment_source.rb
+++ b/lib/agent/configuration/environment_source.rb
@@ -7,7 +7,9 @@ module OasAgent
       class EnvironmentSource
         def to_h
           config = {}
-          config[:agent_key] = ENV["OAS_AGENT_KEY"] unless ENV["OAS_AGENT_KEY"].blank?
+          if (key = ENV["OAS_AGENT_KEY"]) && key != ""
+            config[:agent_key] = key
+          end
 
           config
         end

--- a/spec/agent/configuration/environment_source_test.rb
+++ b/spec/agent/configuration/environment_source_test.rb
@@ -1,0 +1,36 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
+RSpec.describe OasAgent::Agent::Configuration::EnvironmentSource do
+  subject(:config) { described_class.new.to_h }
+
+  context "when the environment specifies a key value" do
+    before do
+      stub_const("ENV", {"OAS_AGENT_KEY" => "alohomora"})
+    end
+
+    it "returns the key in config" do
+      expect(config).to include(agent_key: "alohomora")
+    end
+  end
+
+  context "when the environment specifies a blank value" do
+    before do
+      stub_const("ENV", {"OAS_AGENT_KEY" => ""})
+    end
+
+    it "does not return key in config" do
+      expect(config).not_to include(:agent_key)
+    end
+  end
+
+  context "when the environment does not contain a key" do
+    before do
+      stub_const("ENV", {})
+    end
+
+    it "does not return key in config" do
+      expect(config).not_to include(:agent_key)
+    end
+  end
+end


### PR DESCRIPTION
## What?

- [x] Added spec for `Agent::Configuration::EnvironmentSource` (RSpec <3)
- [x] Update code to check for blank string in native ruby code

## Why?

RSpec makes stubbing out `ENV` easy, so let's add tests to prove this works without ActiveSupport adding `Object#blank?`.

We can't depend on ActiveSupport always being available, so manually check if the environment value read is `""` or not and ignore if it is.